### PR TITLE
Fix Wizard not using latest step values on rerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,12 @@
     "@tsconfig/recommended": "^1.0.1",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@types/react-test-renderer": "^18.0.0",
     "dts-cli": "^1.5.2",
     "husky": "^8.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
     "size-limit": "^8.0.1",
     "tslib": "^2.4.0",
     "typescript": "^4.7.4"

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,5 +1,25 @@
-describe('Thing', () => {
-  it('just works', () => {
-    expect(true).toBe(true);
-  });
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { Wizard } from "../src";
+
+test('next works', () => {
+  const testRenderer = TestRenderer.create(
+    <Wizard
+      initial='start'
+      start={({ next, prev, goto }) => (
+        <div id="start-div" onClick={next}>start</div>
+      )}
+      theNextStep={({ goto }) => (
+        <div id="next-div">the next step</div>
+      )}
+      finish={() => (
+        <div>finish</div>
+      )}
+    />
+  );
+
+  expect(testRenderer.root.findByType('div').props.id).toBe('start-div');
+  act(() => testRenderer.root.findByType('div').props.onClick());
+  expect(testRenderer.root.findByType('div').props.id).toBe('next-div');
+  testRenderer.unmount();
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,3 +1,4 @@
+import { createRef, forwardRef, Ref, useImperativeHandle, useState } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 
 import { Wizard } from "../src";
@@ -21,5 +22,75 @@ test('next works', () => {
   expect(testRenderer.root.findByType('div').props.id).toBe('start-div');
   act(() => testRenderer.root.findByType('div').props.onClick());
   expect(testRenderer.root.findByType('div').props.id).toBe('next-div');
+  testRenderer.unmount();
+});
+
+test('can update steps', () => {
+  const testRenderer = TestRenderer.create(
+    <Wizard
+      initial='start'
+      start={() => (
+        <span>span text 1</span>
+      )}
+    />
+  );
+
+  expect(testRenderer.root.findByType('span').props.children).toBe('span text 1');
+
+  testRenderer.update(
+    <Wizard
+      initial='start'
+      start={() => (
+        <span>span text 2</span>
+      )}
+    />
+  );
+
+  expect(testRenderer.root.findByType('span').props.children).toBe('span text 2');
+  testRenderer.unmount();
+});
+
+test('can update steps without losing state', () => {
+  interface CWSProps {
+    defaultValue: string;
+  }
+
+  interface CWSRef {
+    setValue(value: string): void;
+  }
+
+  const ComponentWithState = forwardRef((props: CWSProps, ref: Ref<CWSRef>) => {
+    const [value, setValue] = useState(props.defaultValue);
+    useImperativeHandle(ref, () => ({
+      setValue
+    }), [setValue]);
+    return <div id="cws">{value}</div>;
+  });
+
+  const cwsRef = createRef<CWSRef>();
+
+  const testRenderer = TestRenderer.create(
+    <Wizard
+      initial='start'
+      start={() => (
+        <ComponentWithState ref={cwsRef} defaultValue="initial value" />
+      )}
+    />
+  );
+
+  expect(testRenderer.root.findByType('div').props.children).toBe('initial value');
+  act(() => cwsRef.current!.setValue('new value'));
+  expect(testRenderer.root.findByType('div').props.children).toBe('new value');
+
+  testRenderer.update(
+    <Wizard
+      initial='start'
+      start={() => (
+        <ComponentWithState ref={cwsRef} defaultValue="initial value" />
+      )}
+    />
+  );
+
+  expect(testRenderer.root.findByType('div').props.children).toBe('new value');
   testRenderer.unmount();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "extends": "@tsconfig/create-react-app/tsconfig.json",
-  "include": ["src", "types"],
+  "include": ["src", "test"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,6 +1508,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.17":
   version "18.0.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.17.tgz#4583d9c322d67efe4b39a935d223edcc7050ccf4"
@@ -4901,6 +4908,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4910,6 +4922,23 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+  dependencies:
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
If you use the Wizard inside of a component that re-renders and passes in new step values, the new step values will not be respected.

For example, a basic component like this won't work at all. The input's value prop will be locked as the empty string (because Wizard forever remembers the value of `first` from the initial render) so the input won't be editable.

```ts
function NameWizard(props) {
  const [name, setName] = useState('');
  return (
    <Wizard
      initial="first"
      first={({next}) =>
        <div>
          <input type="text" value={name} onChange={e => setName(e.target.value)} />
          <button onClick={next}>Next</button>
        </div>
      }
      second={() =>
        <div>Hi {name}</div>
      }
    />
  );
}
```

This is because `componentsRef` is stored inside of a Map that's calculated on the initial render only inside of a useRef call:

```ts
  const componentsRef = React.useRef(
    new Map(stepsList.map((key) => [key, props[key]] as const))
  );
```

Changing the useRef call to a useMemo call so that it's re-calculated whenever `stepsList` is updated fixes this:

```ts
  const componentsRef = React.useMemo(
    () => new Map(stepsList.map((key) => [key, props[key]] as const)),
    [stepsList]
  );
```

---

Once this is fixed, a new issue pops up: whenever a component using Wizard re-renders and passes in new step values, the steps are entirely remounted as new components, causing all state inside of them to be lost and for brand new DOM nodes to be created (losing any uncontrolled component/DOM state including scroll position, text highlighting, focus, etc).

This happens because the step prop values are being used as components (`return (<Component ... />);` where Component is a dynamic value like a prop that doesn't necessarily have a stable value), which will be entirely remounted if a new value is passed in. The [render-props pattern](https://reactjs.org/docs/render-props.html) (`return renderStep({ ... });`) avoids this issue and should almost always be used rather than accepting components as props. The API for users of Wizard is still basically identical (the typescript types are slightly different) and all of the documented examples of Wizard will still keep working as-is.

---

This PR fixes both issues and also adds tests for each of them.